### PR TITLE
fix(build): fix a typo in `covertboxart` makefile

### DIFF
--- a/workspace/all/convertboxart/makefile
+++ b/workspace/all/convertboxart/makefile
@@ -21,7 +21,7 @@ SDL?=SDL
 
 TARGET = convertboxart
 INCDIR = -I. -I../common/ -I../../$(PLATFORM)/platform/ $(MY_INCDIR)
-SOURCE =   $(TARGET).c ../common/utils.c ../common/api.c ../common/scaler.c ../common/$(SDL)_Rotozoom.c ../../$(PLATFORM)/platform/platform.c
+SOURCE =   $(TARGET).c ../common/utils.c ../common/api.c ../common/scaler.c ../common/$(SDL)_rotozoom.c ../../$(PLATFORM)/platform/platform.c
 SOURCE += ../common/pixman-arm-neon-asm.S
 INCDIR += -I../minarch/libretro-common/include/ 
 


### PR DESCRIPTION
Fixed case-sensitive typo: `SDL2_Rotozoom.c` → `SDL2_rotozoom.c`

This was causing build failures on case-sensitive filesystems.