### PR TITLE
all: fix out-of-bounds write to asset_rgbs

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -187,7 +187,7 @@ void InitAssetRects(void) {
 }
 
 
-static uint32_t asset_rgbs[ASSET_COLORS];
+static uint32_t asset_rgbs[ASSET_COUNT];
 GFX_Fonts font;
 
 ///////////////////////////////

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -139,6 +139,8 @@ enum {
 	ASSET_WIFI,
 	ASSET_RED_DOT,
 	ASSET_RED_PAGE,
+
+	ASSET_COUNT, // ASSET_COLORS sits in the middle of this enum, use this to size arrays
 };
 
 typedef struct GFX_Fonts {


### PR DESCRIPTION
Hi! First of all, thank you for keeping MyMinUI alive — it is what made my cheap Allwinner handheld genuinely usable.

While reading through `api.c` I noticed what looks like an out-of-bounds write, and I thought it was worth reporting even though it does not seem to cause visible symptoms today.

### The problem

`asset_rgbs` is declared as:

```c
static uint32_t asset_rgbs[ASSET_COLORS];
```

`ASSET_COLORS` sits in the middle of the `ASSET_*` enum, so this array has **14** entries (`ASSET_WHITE_PILL` = 0 through `ASSET_HOLE` = 13).

But `GFX_init()` also does:

```c
asset_rgbs[ASSET_RED_DOT]  = RGB_RED;
asset_rgbs[ASSET_RED_PAGE] = RGB_RED;
```

and those constants evaluate to **26** and **27**, since they come after `ASSET_COLORS`, `ASSET_BRIGHTNESS`, the battery assets, the scroll arrows and `ASSET_WIFI`. So both assignments land twelve and thirteen slots past the end of the array, overwriting whatever the linker placed after `asset_rgbs` in `.bss`.

`GFX_blitAsset()` and `GFX_blitPill()` also read `asset_rgbs[asset]` for an arbitrary asset id, so out-of-range reads are reachable through the same enum values.

This runs on every startup, on every platform.

### The fix

`ASSET_COLORS` cannot simply move to the end of the enum, because the colour block has to stay contiguous for it to keep meaning "number of colours". So this adds a separate `ASSET_COUNT` terminator and sizes the array with it:

```c
	ASSET_WIFI,
	ASSET_RED_DOT,
	ASSET_RED_PAGE,

	ASSET_COUNT, // ASSET_COLORS sits in the middle of this enum, use this to size arrays
};
```

```c
static uint32_t asset_rgbs[ASSET_COUNT];
```

No existing `ASSET_*` constant changes value, so nothing else in the tree is affected. Three lines across two files.

### Testing

Built for `m21` and ran on the device (LOONG MAY-M21, Allwinner H133). No behaviour change, which is expected — the point is that the two stray writes now land inside the array.

I am happy to adjust the naming or the comment if you would prefer something else.
