### PR TITLE
minarch: show the save state description on the right menu item

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -4506,7 +4506,7 @@ static MenuList options_menu = {
 };
 
 static void OptionSaveChanges_updateDesc(void) {
-	options_menu.items[4].desc = getSaveDesc();
+	options_menu.items[5].desc = getSaveDesc(); // 5 is "Save Changes", 4 is "Shortcuts"
 }
 
 #define OPTION_PADDING 8


### PR DESCRIPTION
Hi! A small one-line fix in the in-game options menu.

### The problem

`OptionSaveChanges_updateDesc()` writes the config description into `options_menu.items[4]`:

```c
static void OptionSaveChanges_updateDesc(void) {
	options_menu.items[4].desc = getSaveDesc();
}
```

But the menu items are:

```
0  Frontend
1  Emulator
2  Cheats
3  Controls
4  Shortcuts
5  Save Changes
```

So `Using game config.` / `Using console config.` shows up as the description of **Shortcuts**, and **Save Changes** — the item it actually describes — has no description at all.

My guess is the index was correct before `Cheats` was added to the list, and just did not get bumped.

(The neighbouring `options_menu.items[1].desc = (char*)core.version;` is fine — `1` is still `Emulator`.)

### The fix

```c
options_menu.items[5].desc = getSaveDesc(); // 5 is "Save Changes", 4 is "Shortcuts"
```

I kept the change minimal so it is easy to review, but I am happy to rework it into a named enum for the menu indices if you would rather not keep a bare number here — that would stop it drifting again the next time an item is inserted. Just say the word.

### Testing

Built for `m21` and checked on the device (LOONG MAY-M21, Allwinner H133): the description now shows under `Save Changes`, and `Shortcuts` no longer carries it.
