### PR TITLE
m21: repair bit-rot that broke the M21 build

### DIFF
--- a/workspace/m21/platform/platform.c
+++ b/workspace/m21/platform/platform.c
@@ -1016,7 +1016,12 @@ SDL_Surface* PLAT_initVideo(void) {
 	PLAT_clearAll();
 	pan_display(vid.page * vid.ionmmapfailed);
 	vid.page = 1;
-	vid.sharpness = SHARPNESS_SOFT;
+	// SHARPNESS_SOFT is not defined anywhere in the tree; the common enum in
+	// all/common/api.h now spells this SCALER_NEAREST/SCALER_SHARP. vid.sharpness
+	// is write-only (never read here or elsewhere) and PLAT_setSharpness() ignores
+	// its argument, so dropping the assignment is behaviour-neutral and unblocks
+	// the build. Restore it if the sharpness path is ever finished.
+	// vid.sharpness = SHARPNESS_SOFT;
 	return vid.screen;
 }
 
@@ -1136,6 +1141,16 @@ void PLAT_vsync(int remaining) {
 	} else {
 		pan_display(vid.page * vid.ionmmapfailed);
 	}
+}
+
+// Part of the platform contract (all/common/api.h) but never implemented here --
+// it was added to the shared code after M21 support stopped, so linking failed.
+// The h700 keeps a vid.vsync_refresh field seeded with this same 60Hz value and
+// then refines it via measureAverageVsyncNs(); neither the field nor that
+// calibration exists on this platform, so we return the fixed panel rate.
+// Value is in nanoseconds.
+uint32_t PLAT_getVsyncInterval(void) {
+	return 16666700; // 60Hz
 }
 
 void PLAT_blitRenderer(GFX_Renderer* renderer) {


### PR DESCRIPTION
Hi again! This one is a bit more than a bug fix, so I want to give you the full context up front.

I have a LOONG MAY-M21 (Allwinner H133), and I got MyMinUI running on it. The `workspace/m21/` tree is all still here — makefile, keymon, platform, cores, overclock, show — and the `m21:` target still exists in the makefile; only `PLATFORMS` had it commented out. Two things had bit-rotted in the meantime, and both are interface breakages rather than logic changes:

### 1. `SHARPNESS_SOFT` no longer exists

```c
vid.sharpness = SHARPNESS_SOFT;
```

That constant is not defined anywhere in the tree any more — the common enum in `all/common/api.h` is now `SCALER_NEAREST` / `SCALER_SHARP`. `vid.sharpness` appears exactly once in the whole file (this assignment) and is never read, and `PLAT_setSharpness()` ignores its argument, so dropping the assignment is behaviour-neutral. I left it commented rather than deleted, in case the sharpness path is ever picked up again — happy to delete it outright if you prefer.

### 2. `PLAT_getVsyncInterval()` was missing

It was added to the platform contract after M21 support stopped, so the link failed. It returns the fixed 60Hz panel rate in nanoseconds:

```c
uint32_t PLAT_getVsyncInterval(void) {
	return 16666700; // 60Hz
}
```

This is the same value the h700 seeds its `vid.vsync_refresh` with before refining it through `measureAverageVsyncNs()`. Neither that field nor that calibration exists on this platform, so returning the panel rate directly seemed like the honest equivalent. If you would rather it did something else, tell me and I will change it.

(`PLAT_initLid` / `PLAT_lidChanged` are also absent, but so are they on `my282`, so I assume they are genuinely optional and left them alone.)

### One dependency

On a clean clone the build still stops before this matters, on the missing `skeleton/EXTRAS/Bios/DOOM/.keep` — that is #112, which is a one-file change and not specific to M21. With #112 applied, `make m21` completes here.

### Testing

Built with the `sjgam_m21_toolchain` release blob and run on the actual device: launcher, in-game menu, save states and 20 cores. It has been my daily driver for a couple of days now.

Note that `makefile.toolchain` clones `shauninman/union-m21-toolchain`, which does not exist any more — I extracted the toolchain from your `sjgam_m21_toolchain` release into `toolchains/m21-toolchain/` by hand. Worth a separate issue or a README line, but I did not want to mix it into this PR.

### On putting M21 back in PLATFORMS

I deliberately did **not** re-add `m21` to `PLATFORMS` in this PR, because that would make you responsible for a platform you cannot test — I read that you had to drop it after your unit died, and it is not my place to hand that back to you unasked.

But if it would be useful: **I have the hardware and I am happy to test M21 builds before each release**, and to look after that platform's corner of the tree. No pressure either way, and no expectations if you would rather keep it out — the fix above stands on its own regardless, since `make m21` works as a manual target.

Thanks for keeping this project going.
