### PR TITLE
all: fix red channel in copyRow_565_to_8888_NEON

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -2848,7 +2848,7 @@ static inline void copyRow_565_to_8888_NEON(uint16_t *src, uint32_t *dst, int wi
 
         // 2. Estrazione componenti tramite bitwise and e shift
         // Rosso: (pixel >> 11) & 0x1F  -> poi shift a 8 bit (<< 3)
-        uint8x8_t r = vshrn_n_u16(v_565, 8); // Shift a destra di 8 e stringi a 8 bit
+        uint8x8_t r = vmovn_u16(vshrq_n_u16(v_565, 11)); // (pixel >> 11) & 0x1F: isola il rosso prima di stringere
         r = vshl_n_u8(r, 3);                 // Porta a 8 bit (5 bit + 3)
 
         // Verde: (pixel >> 5) & 0x3F   -> poi shift a 8 bit (<< 2)


### PR DESCRIPTION
Hi! This is the bug I mentioned in #114 — offered there, delivered here, with the full story.

### The bug

In `copyRow_565_to_8888_NEON()` (used only by `FlipRotate000()`):

```c
uint8x8_t r = vshrn_n_u16(v_565, 8);
r = vshl_n_u8(r, 3);
```

The first line takes the pixel's high byte, which is `RRRRRGGG` — the top 3 green bits are still in there. Shifting left 3 then drops the top 3 **red** bits off the byte, while the green bits survive into red's low positions. Net effect: mid greys gain a lot of red (they go visibly salmon) and dark greys lose red entirely.

Green and blue only look right by luck: the bits that spill into their lanes get shifted out by their own `<<2`/`<<3`. The scalar tail of the same function masks properly — only the NEON lane is wrong.

`FlipRotate000()` is currently called only from the m21 platform's framebuffer fallback path, which is probably why this has never been reported: it almost never runs. It showed up the moment I wired the m21's ion path to 32bpp (the sharp-scaler work discussed in #114).

### The fix

One line, matching the scalar tail exactly:

```c
uint8x8_t r = vmovn_u16(vshrq_n_u16(v_565, 11)); // (pixel >> 11) & 0x1F
```

### Testing

Built for `m21` and ran on the device (LOONG MAY-M21, Allwinner H133), with the 32-bit flip active in every path. Before: grey UI elements were salmon. After: greys are grey — launcher, menus and games, nearest and sharp alike.

Not run on other platforms, but nothing else calls this helper, so no other platform is affected either way. Happy to adjust the comment wording or the approach if you would rather do it differently.
